### PR TITLE
Make rolllbar-log4j OSGi enabled

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ This is a library for rollbar and log4j to integrate Java apps with [Rollbar](ht
 The library is inspired by [rollbar-java] (https://github.com/rafael-munoz/rollbar-java) by Rafael Munoz and
 [rollbar-maven] (https://github.com/borjafpa/rollbar-maven) by Borja Pernia
 
+Maven will produce an OSGI-enabled JAR file.
 
 setup
 =============

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <groupId>com.github.rollbar.log4j</groupId>
     <artifactId>appender</artifactId>
     <version>1.0</version>
-    <packaging>jar</packaging>
+    <packaging>bundle</packaging>
 
     <dependencies>
         <dependency>
@@ -17,7 +17,7 @@
         <dependency>
             <groupId>javax.servlet</groupId>
             <artifactId>javax.servlet-api</artifactId>
-            <version>3.1.0</version>
+            <version>3.0.1</version>
         </dependency>
         <dependency>
             <groupId>org.json</groupId>
@@ -37,6 +37,27 @@
                     <target>1.6</target>
                 </configuration>
             </plugin>
+              <plugin>
+                  <groupId>org.apache.felix</groupId>
+                  <artifactId>maven-bundle-plugin</artifactId>
+                  <version>1.4.0</version>
+                  <extensions>true</extensions>
+                  <configuration>
+                      <instructions>
+                          <Bundle-SymbolicName>${project.groupId}</Bundle-SymbolicName>
+                          <Bundle-Name>${project.artifactId}</Bundle-Name>
+                          <Bundle-Version>1.0.0</Bundle-Version>
+                          <Import-Package>
+                              org.apache.log4j.*,
+                              org.json.*,
+                              javax.servlet.*;version="[2.5.0,2.9.0]"
+                          </Import-Package>
+                          <Export-Package>
+                          	com.github.rollbar.log4j.*
+                          </Export-Package>
+                      </instructions>
+                  </configuration>
+              </plugin>
         </plugins>
     </build>
 


### PR DESCRIPTION
Create correct manifest from Maven to use the JAR bundle in an OSGi environment
